### PR TITLE
feat: return pod cpu and memory metrics

### DIFF
--- a/api/handlers/shared/metrics.go
+++ b/api/handlers/shared/metrics.go
@@ -1,0 +1,105 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	restError "github.com/kotalco/community-api/pkg/errors"
+	"github.com/kotalco/community-api/pkg/shared"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"time"
+
+	"github.com/gofiber/websocket/v2"
+	"github.com/kotalco/community-api/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const megabyte = "MB"
+const milliCore = "m"
+
+type metricDto struct {
+	Value int64  `json:"value"`
+	Unit  string `json:"unit"`
+}
+type metricsResponseDto struct {
+	Cpu    metricDto `json:"cpu"`
+	Memory metricDto `json:"memory"`
+}
+
+// Metrics returns a websocket that emits cpu and memory usage
+func Metrics(c *websocket.Conn) {
+	defer c.Close()
+
+	if os.Getenv("MOCK") == "true" {
+		for {
+			response := new(metricsResponseDto)
+			response.Cpu.Value = 0
+			response.Cpu.Unit = milliCore
+			response.Memory.Value = 0
+			response.Memory.Unit = megabyte
+			c.WriteJSON(shared.NewResponse(response))
+			time.Sleep(time.Second * 3)
+		}
+	}
+
+	pod := &corev1.Pod{}
+	key := types.NamespacedName{
+		Namespace: c.Locals("namespace").(string),
+		Name:      fmt.Sprintf("%s-0", c.Params("name")),
+	}
+
+	sts := &appsv1.StatefulSet{}
+	stsKey := types.NamespacedName{
+		Namespace: c.Locals("namespace").(string),
+		Name:      c.Params("name"),
+	}
+
+	for {
+
+		err := k8sClient.Get(context.Background(), key, pod)
+		if err != nil {
+			// is the pod error due to sts has been deleted ?
+			stsErr := k8sClient.Get(context.Background(), stsKey, sts)
+			if apierrors.IsNotFound(stsErr) {
+				c.WriteJSON(shared.NewResponse(restError.NewNotFoundError(stsErr.Error())))
+				return
+			}
+
+			if apierrors.IsNotFound(err) {
+				err = errors.New("NotFound")
+			}
+			c.WriteJSON(shared.NewResponse(restError.NewNotFoundError(err.Error())))
+
+			time.Sleep(3 * time.Second)
+			continue
+		}
+
+		metricsClientset := k8s.MetricsClientset()
+		opts := metav1.GetOptions{}
+		metrics, err := metricsClientset.MetricsV1beta1().PodMetricses(key.Namespace).Get(context.Background(), key.Name, opts)
+		if err != nil {
+			c.WriteJSON(restError.NewInternalServerError(err.Error()))
+			return
+		}
+
+		response := new(metricsResponseDto)
+		//cpu are represented in nano-cores which is 1/1000000000 (1 billionth) of a cpu
+		//scaling to milli core which is 1/1000 of a cpu
+		response.Cpu.Value = metrics.Containers[0].Usage.Cpu().ScaledValue(resource.Milli)
+		response.Cpu.Unit = milliCore
+		//memory usage are represented in ki  (1 Kibibyte = 1.024 kilobytes) (1000 Kibibyte  = 1.024 megabytes)
+		//scaling to megabytes
+		//the value won't overflow int64 coz we are scaling to megabytes
+		response.Memory.Value = metrics.Containers[0].Usage.Memory().ScaledValue(resource.Mega)
+		response.Memory.Unit = megabyte
+
+		c.WriteJSON(shared.NewResponse(response))
+		time.Sleep(time.Second * 3)
+	}
+
+}

--- a/api/url_mapping.go
+++ b/api/url_mapping.go
@@ -40,6 +40,7 @@ func MapUrl(app *fiber.App, handlers ...fiber.Handler) {
 	chainlinkNodes.Get("/:name", chainlink.ValidateNodeExist, chainlink.Get)
 	chainlinkNodes.Get("/:name/logs", websocket.New(shared.Logger))
 	chainlinkNodes.Get("/:name/status", websocket.New(shared.Status))
+	chainlinkNodes.Get("/:name/metrics", websocket.New(shared.Metrics))
 	chainlinkNodes.Put("/:name", chainlink.ValidateNodeExist, chainlink.Update)
 	chainlinkNodes.Delete("/:name", chainlink.ValidateNodeExist, chainlink.Delete)
 
@@ -53,6 +54,7 @@ func MapUrl(app *fiber.App, handlers ...fiber.Handler) {
 	ethereumNodes.Get("/:name/logs", websocket.New(shared.Logger))
 	ethereumNodes.Get("/:name/status", websocket.New(shared.Status))
 	ethereumNodes.Get("/:name/stats", websocket.New(ethereum.Stats))
+	ethereumNodes.Get("/:name/metrics", websocket.New(shared.Metrics))
 	ethereumNodes.Put("/:name", ethereum.ValidateNodeExist, ethereum.Update)
 	ethereumNodes.Delete("/:name", ethereum.ValidateNodeExist, ethereum.Delete)
 
@@ -83,6 +85,7 @@ func MapUrl(app *fiber.App, handlers ...fiber.Handler) {
 	beaconnodesGroup.Get("/:name", beacon_node.ValidateBeaconNodeExist, beacon_node.Get)
 	beaconnodesGroup.Get("/:name/logs", websocket.New(shared.Logger))
 	beaconnodesGroup.Get("/:name/status", websocket.New(shared.Status))
+	beaconnodesGroup.Get("/:name/metrics", websocket.New(shared.Metrics))
 	beaconnodesGroup.Put("/:name", beacon_node.ValidateBeaconNodeExist, beacon_node.Update)
 	beaconnodesGroup.Delete("/:name", beacon_node.ValidateBeaconNodeExist, beacon_node.Delete)
 	//validators group
@@ -93,6 +96,7 @@ func MapUrl(app *fiber.App, handlers ...fiber.Handler) {
 	validatorsGroup.Get("/:name", validator.ValidateValidatorExist, validator.Get)
 	validatorsGroup.Get("/:name/logs", websocket.New(shared.Logger))
 	validatorsGroup.Get("/:name/status", websocket.New(shared.Status))
+	validatorsGroup.Get("/:name/metrics", websocket.New(shared.Metrics))
 	validatorsGroup.Put("/:name", validator.ValidateValidatorExist, validator.Update)
 	validatorsGroup.Delete("/:name", validator.ValidateValidatorExist, validator.Delete)
 
@@ -105,6 +109,7 @@ func MapUrl(app *fiber.App, handlers ...fiber.Handler) {
 	filecoinNodes.Get("/:name", filecoin.ValidateNodeExist, filecoin.Get)
 	filecoinNodes.Get("/:name/logs", websocket.New(shared.Logger))
 	filecoinNodes.Get("/:name/status", websocket.New(shared.Status))
+	filecoinNodes.Get("/:name/metrics", websocket.New(shared.Metrics))
 	filecoinNodes.Put("/:name", filecoin.ValidateNodeExist, filecoin.Update)
 	filecoinNodes.Delete("/:name", filecoin.ValidateNodeExist, filecoin.Delete)
 
@@ -118,6 +123,7 @@ func MapUrl(app *fiber.App, handlers ...fiber.Handler) {
 	ipfsPeersGroup.Get("/:name", ipfs_peer.ValidatePeerExist, ipfs_peer.Get)
 	ipfsPeersGroup.Get("/:name/logs", websocket.New(shared.Logger))
 	ipfsPeersGroup.Get("/:name/status", websocket.New(shared.Status))
+	ipfsPeersGroup.Get("/:name/metrics", websocket.New(shared.Metrics))
 	ipfsPeersGroup.Put("/:name", ipfs_peer.ValidatePeerExist, ipfs_peer.Update)
 	ipfsPeersGroup.Delete("/:name", ipfs_peer.ValidatePeerExist, ipfs_peer.Delete)
 	//ipfs peer group
@@ -128,6 +134,7 @@ func MapUrl(app *fiber.App, handlers ...fiber.Handler) {
 	clusterpeersGroup.Get("/:name", ipfs_cluster_peer.ValidateClusterPeerExist, ipfs_cluster_peer.Get)
 	clusterpeersGroup.Get("/:name/logs", websocket.New(shared.Logger))
 	clusterpeersGroup.Get("/:name/status", websocket.New(shared.Status))
+	clusterpeersGroup.Get("/:name/metrics", websocket.New(shared.Metrics))
 	clusterpeersGroup.Put("/:name", ipfs_cluster_peer.ValidateClusterPeerExist, ipfs_cluster_peer.Update)
 	clusterpeersGroup.Delete("/:name", ipfs_cluster_peer.ValidateClusterPeerExist, ipfs_cluster_peer.Delete)
 
@@ -141,6 +148,7 @@ func MapUrl(app *fiber.App, handlers ...fiber.Handler) {
 	nearNodesGroup.Get("/:name/logs", websocket.New(shared.Logger))
 	nearNodesGroup.Get("/:name/status", websocket.New(shared.Status))
 	nearNodesGroup.Get("/:name/stats", websocket.New(near.Stats))
+	nearNodesGroup.Get("/:name/metrics", websocket.New(shared.Metrics))
 	nearNodesGroup.Put("/:name", near.ValidateNodeExist, near.Update)
 	nearNodesGroup.Delete("/:name", near.ValidateNodeExist, near.Delete)
 
@@ -153,6 +161,7 @@ func MapUrl(app *fiber.App, handlers ...fiber.Handler) {
 	polkadotNodesGroup.Get("/:name/logs", websocket.New(shared.Logger))
 	polkadotNodesGroup.Get("/:name/status", websocket.New(shared.Status))
 	polkadotNodesGroup.Get("/:name/stats", websocket.New(polkadot.Stats))
+	polkadotNodesGroup.Get("/:name/metrics", websocket.New(shared.Metrics))
 	polkadotNodesGroup.Put("/:name", polkadot.ValidateNodeExist, polkadot.Update)
 	polkadotNodesGroup.Delete("/:name", polkadot.ValidateNodeExist, polkadot.Delete)
 


### PR DESCRIPTION
### Details
Each protocol should return it's pod memory and cpu metrics 
Memory unit of measurement is MB / megabytes
Cpu unit of measurement is  m / millicore

### Example Response
```
{
    "data": {
        "cpu": {
            "value": 38,
            "unit": "mCpu"
        },
        "memory": {
            "value": 2507,
            "unit": "MB"
        }
    }
}
```