### PR TITLE
69 stream ethereum beacon node stats over websocket

### DIFF
--- a/api/handlers/ethereum2/beacon_node/beacon_node_handler.go
+++ b/api/handlers/ethereum2/beacon_node/beacon_node_handler.go
@@ -213,26 +213,26 @@ func Stats(c *websocket.Conn) {
 		}
 
 		baseUrl := fmt.Sprintf("http://%s:%d/eth/v1/node/", "localhost", beaconnode.Spec.RESTPort)
-		jobs <- request{name: "peerCount", url: fmt.Sprintf("%speer_count", baseUrl)}
+		jobs <- request{name: "peers", url: fmt.Sprintf("%speer_count", baseUrl)}
 		jobs <- request{name: "isSyncing", url: fmt.Sprintf("%ssyncing", baseUrl)}
 
 		close(jobs)
 
 		type NodePeerCountDto struct {
-			Disconnected  string
-			Connecting    string
-			Connected     string
-			Disconnecting string
+			Disconnected  string `json:"disconnected"`
+			Connecting    string `json:"connecting"`
+			Connected     string `json:"connected"`
+			Disconnecting string `json:"disconnecting"`
 		}
 		type NodeSyncingStatusDto struct {
-			HeadSlot     string
-			SyncDistance string
-			IsSyncing    bool
-			IsOptimistic bool
+			HeadSlot     string `json:"head_slot"`
+			SyncDistance string `json:"sync_distance"`
+			IsSyncing    bool   `json:"is_syncing"`
+			IsOptimistic bool   `json:"is_optimistic"`
 		}
 		var nodeStatResponseDto struct {
-			PeerCount     NodePeerCountDto     `json:"peer_count"`
-			SyncingStatus NodeSyncingStatusDto `json:"syncing_status"`
+			Peers   NodePeerCountDto     `json:"peers"`
+			Syncing NodeSyncingStatusDto `json:"syncing"`
 		}
 
 		newNodeResponse := nodeStatResponseDto
@@ -246,7 +246,7 @@ func Stats(c *websocket.Conn) {
 				continue
 			}
 			switch resp.name {
-			case "peerCount":
+			case "peers":
 				var responseBody struct {
 					Data NodePeerCountDto `json:"data"`
 				}
@@ -257,10 +257,10 @@ func Stats(c *websocket.Conn) {
 					})
 					break
 				}
-				newNodeResponse.PeerCount.Disconnected = responseBody.Data.Disconnected
-				newNodeResponse.PeerCount.Connecting = responseBody.Data.Connecting
-				newNodeResponse.PeerCount.Connected = responseBody.Data.Connected
-				newNodeResponse.PeerCount.Disconnecting = responseBody.Data.Disconnecting
+				newNodeResponse.Peers.Disconnected = responseBody.Data.Disconnected
+				newNodeResponse.Peers.Connecting = responseBody.Data.Connecting
+				newNodeResponse.Peers.Connected = responseBody.Data.Connected
+				newNodeResponse.Peers.Disconnecting = responseBody.Data.Disconnecting
 				break
 			case "isSyncing":
 				var responseBody struct {
@@ -273,10 +273,10 @@ func Stats(c *websocket.Conn) {
 					})
 					break
 				}
-				newNodeResponse.SyncingStatus.HeadSlot = responseBody.Data.HeadSlot
-				newNodeResponse.SyncingStatus.SyncDistance = responseBody.Data.SyncDistance
-				newNodeResponse.SyncingStatus.IsSyncing = responseBody.Data.IsSyncing
-				newNodeResponse.SyncingStatus.IsOptimistic = responseBody.Data.IsOptimistic
+				newNodeResponse.Syncing.HeadSlot = responseBody.Data.HeadSlot
+				newNodeResponse.Syncing.SyncDistance = responseBody.Data.SyncDistance
+				newNodeResponse.Syncing.IsSyncing = responseBody.Data.IsSyncing
+				newNodeResponse.Syncing.IsOptimistic = responseBody.Data.IsOptimistic
 				break
 			}
 		}

--- a/api/handlers/ethereum2/beacon_node/beacon_node_handler.go
+++ b/api/handlers/ethereum2/beacon_node/beacon_node_handler.go
@@ -1,23 +1,44 @@
 package beacon_node
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/websocket/v2"
 	"github.com/kotalco/community-api/internal/ethereum2/beacon_node"
 	restErrors "github.com/kotalco/community-api/pkg/errors"
+	"github.com/kotalco/community-api/pkg/k8s"
 	"github.com/kotalco/community-api/pkg/shared"
 	ethereum2v1alpha1 "github.com/kotalco/kotal/apis/ethereum2/v1alpha1"
+	"io/ioutil"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"net/http"
 	"sort"
 	"strconv"
+	"time"
 )
+
+type request struct {
+	url  string
+	name string
+}
+type result struct {
+	err  error
+	name string
+	data []byte
+}
 
 const (
 	nameKeyword = "name"
 )
 
-var service = beacon_node.NewBeaconNodeService()
+var (
+	service   = beacon_node.NewBeaconNodeService()
+	k8sClient = k8s.NewClientService()
+)
 
 // Get gets a single ethereum 2.0 beacon node by name
 // 1-get the node validated from ValidateNodeExist method
@@ -150,4 +171,149 @@ func ValidateBeaconNodeExist(c *fiber.Ctx) error {
 
 	c.Locals("node", node)
 	return c.Next()
+}
+
+// Stats returns a websocket that emits peer  count and node syncing status
+func Stats(c *websocket.Conn) {
+	defer c.Close()
+
+	name := c.Params("name")
+	beaconnode := &ethereum2v1alpha1.BeaconNode{}
+	nameSpacedName := types.NamespacedName{
+		Namespace: c.Locals("namespace").(string),
+		Name:      name,
+	}
+	err := k8sClient.Get(context.Background(), nameSpacedName, beaconnode)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			c.WriteJSON(fiber.Map{
+				"error": fmt.Sprintf("peer by name %s doesn't exist", name),
+			})
+			return
+		}
+		c.WriteJSON(fiber.Map{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	if !beaconnode.Spec.REST {
+		c.WriteJSON(fiber.Map{
+			"error": "node rest is not enabled",
+		})
+		return
+	}
+
+	for {
+		jobs := make(chan request, 2)
+		results := make(chan result, 2)
+
+		for i := 0; i < 2; i++ {
+			go worker(jobs, results)
+		}
+
+		baseUrl := fmt.Sprintf("http://%s:%d/eth/v1/node/", "localhost", beaconnode.Spec.RESTPort)
+		jobs <- request{name: "peerCount", url: fmt.Sprintf("%speer_count", baseUrl)}
+		jobs <- request{name: "isSyncing", url: fmt.Sprintf("%ssyncing", baseUrl)}
+
+		close(jobs)
+
+		type NodePeerCountDto struct {
+			Disconnected  string
+			Connecting    string
+			Connected     string
+			Disconnecting string
+		}
+		type NodeSyncingStatusDto struct {
+			HeadSlot     string
+			SyncDistance string
+			IsSyncing    bool
+			IsOptimistic bool
+		}
+		var nodeStatResponseDto struct {
+			PeerCount     NodePeerCountDto     `json:"peer_count"`
+			SyncingStatus NodeSyncingStatusDto `json:"syncing_status"`
+		}
+
+		newNodeResponse := nodeStatResponseDto
+
+		for i := 0; i < 2; i++ {
+			resp := <-results
+			if resp.err != nil {
+				c.WriteJSON(fiber.Map{
+					"error": err.Error(),
+				})
+				continue
+			}
+			switch resp.name {
+			case "peerCount":
+				var responseBody struct {
+					Data NodePeerCountDto `json:"data"`
+				}
+				err = json.Unmarshal(resp.data, &responseBody)
+				if err != nil {
+					c.WriteJSON(fiber.Map{
+						"error": err.Error(),
+					})
+					break
+				}
+				newNodeResponse.PeerCount.Disconnected = responseBody.Data.Disconnected
+				newNodeResponse.PeerCount.Connecting = responseBody.Data.Connecting
+				newNodeResponse.PeerCount.Connected = responseBody.Data.Connected
+				newNodeResponse.PeerCount.Disconnecting = responseBody.Data.Disconnecting
+				break
+			case "isSyncing":
+				var responseBody struct {
+					Data NodeSyncingStatusDto `json:"data"`
+				}
+				err = json.Unmarshal(resp.data, &responseBody)
+				if err != nil {
+					c.WriteJSON(fiber.Map{
+						"error": err.Error(),
+					})
+					break
+				}
+				newNodeResponse.SyncingStatus.HeadSlot = responseBody.Data.HeadSlot
+				newNodeResponse.SyncingStatus.SyncDistance = responseBody.Data.SyncDistance
+				newNodeResponse.SyncingStatus.IsSyncing = responseBody.Data.IsSyncing
+				newNodeResponse.SyncingStatus.IsOptimistic = responseBody.Data.IsOptimistic
+				break
+			}
+		}
+		close(results)
+
+		c.WriteJSON(newNodeResponse)
+
+		time.Sleep(time.Second * 3)
+	}
+}
+
+// worker is a  collection of threads for the beacon node stats
+func worker(jobs <-chan request, results chan<- result) {
+	chanRes := result{}
+	for job := range jobs {
+		chanRes.name = job.name
+
+		client := http.Client{
+			Timeout: 4 * time.Second,
+		}
+		req, err := http.NewRequest(http.MethodGet, job.url, bytes.NewReader([]byte(nil)))
+		if err != nil {
+			chanRes.err = err
+			return
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			chanRes.err = err
+			return
+		}
+
+		responseData, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			chanRes.err = err
+			return
+		}
+		chanRes.data = responseData
+		results <- chanRes
+	}
 }

--- a/api/handlers/ethereum2/beacon_node/beacon_node_handler.go
+++ b/api/handlers/ethereum2/beacon_node/beacon_node_handler.go
@@ -219,16 +219,16 @@ func Stats(c *websocket.Conn) {
 		close(jobs)
 
 		type NodePeerCountDto struct {
-			Disconnected  string `json:"disconnected"`
-			Connecting    string `json:"connecting"`
-			Connected     string `json:"connected"`
-			Disconnecting string `json:"disconnecting"`
+			Disconnected  int `json:"disconnected"`
+			Connecting    int `json:"connecting"`
+			Connected     int `json:"connected"`
+			Disconnecting int `json:"disconnecting"`
 		}
 		type NodeSyncingStatusDto struct {
-			HeadSlot     string `json:"head_slot"`
-			SyncDistance string `json:"sync_distance"`
-			IsSyncing    bool   `json:"is_syncing"`
-			IsOptimistic bool   `json:"is_optimistic"`
+			HeadSlot     int  `json:"head_slot"`
+			SyncDistance int  `json:"sync_distance"`
+			IsSyncing    bool `json:"is_syncing"`
+			IsOptimistic bool `json:"is_optimistic"`
 		}
 		var nodeStatResponseDto struct {
 			Peers   NodePeerCountDto     `json:"peers"`
@@ -248,7 +248,12 @@ func Stats(c *websocket.Conn) {
 			switch resp.name {
 			case "peers":
 				var responseBody struct {
-					Data NodePeerCountDto `json:"data"`
+					Data struct {
+						Disconnected  string `json:"disconnected"`
+						Connecting    string `json:"connecting"`
+						Connected     string `json:"connected"`
+						Disconnecting string `json:"disconnecting"`
+					} `json:"data"`
 				}
 				err = json.Unmarshal(resp.data, &responseBody)
 				if err != nil {
@@ -257,14 +262,19 @@ func Stats(c *websocket.Conn) {
 					})
 					break
 				}
-				newNodeResponse.Peers.Disconnected = responseBody.Data.Disconnected
-				newNodeResponse.Peers.Connecting = responseBody.Data.Connecting
-				newNodeResponse.Peers.Connected = responseBody.Data.Connected
-				newNodeResponse.Peers.Disconnecting = responseBody.Data.Disconnecting
+				newNodeResponse.Peers.Disconnected, _ = strconv.Atoi(responseBody.Data.Disconnected)
+				newNodeResponse.Peers.Connecting, _ = strconv.Atoi(responseBody.Data.Connecting)
+				newNodeResponse.Peers.Connected, _ = strconv.Atoi(responseBody.Data.Connected)
+				newNodeResponse.Peers.Disconnecting, _ = strconv.Atoi(responseBody.Data.Disconnecting)
 				break
 			case "isSyncing":
 				var responseBody struct {
-					Data NodeSyncingStatusDto `json:"data"`
+					Data struct {
+						HeadSlot     string `json:"head_slot"`
+						SyncDistance string `json:"sync_distance"`
+						IsSyncing    bool   `json:"is_syncing"`
+						IsOptimistic bool   `json:"is_optimistic"`
+					} `json:"data"`
 				}
 				err = json.Unmarshal(resp.data, &responseBody)
 				if err != nil {
@@ -273,8 +283,8 @@ func Stats(c *websocket.Conn) {
 					})
 					break
 				}
-				newNodeResponse.Syncing.HeadSlot = responseBody.Data.HeadSlot
-				newNodeResponse.Syncing.SyncDistance = responseBody.Data.SyncDistance
+				newNodeResponse.Syncing.HeadSlot, _ = strconv.Atoi(responseBody.Data.HeadSlot)
+				newNodeResponse.Syncing.SyncDistance, _ = strconv.Atoi(responseBody.Data.SyncDistance)
 				newNodeResponse.Syncing.IsSyncing = responseBody.Data.IsSyncing
 				newNodeResponse.Syncing.IsOptimistic = responseBody.Data.IsOptimistic
 				break

--- a/api/handlers/ethereum2/beacon_node/beacon_node_handler.go
+++ b/api/handlers/ethereum2/beacon_node/beacon_node_handler.go
@@ -212,7 +212,7 @@ func Stats(c *websocket.Conn) {
 			go worker(jobs, results)
 		}
 
-		baseUrl := fmt.Sprintf("http://%s:%d/eth/v1/node/", "localhost", beaconnode.Spec.RESTPort)
+		baseUrl := fmt.Sprintf("http://%s.%s:%d/eth/v1/node/", beaconnode.Name, nameSpacedName.Namespace, beaconnode.Spec.RESTPort)
 		jobs <- request{name: "peers", url: fmt.Sprintf("%speer_count", baseUrl)}
 		jobs <- request{name: "isSyncing", url: fmt.Sprintf("%ssyncing", baseUrl)}
 

--- a/api/url_mapping.go
+++ b/api/url_mapping.go
@@ -86,6 +86,7 @@ func MapUrl(app *fiber.App, handlers ...fiber.Handler) {
 	beaconnodesGroup.Get("/:name/logs", websocket.New(shared.Logger))
 	beaconnodesGroup.Get("/:name/status", websocket.New(shared.Status))
 	beaconnodesGroup.Get("/:name/metrics", websocket.New(shared.Metrics))
+	beaconnodesGroup.Get("/:name/stats", websocket.New(beacon_node.Stats))
 	beaconnodesGroup.Put("/:name", beacon_node.ValidateBeaconNodeExist, beacon_node.Update)
 	beaconnodesGroup.Delete("/:name", beacon_node.ValidateBeaconNodeExist, beacon_node.Delete)
 	//validators group


### PR DESCRIPTION
## Details
beacon node should 
- Retrieves number of known peers [https://ethereum.github.io/beacon-APIs/#/Node/getPeerCount](url)
- Describe if it's currently syncing or not, and if it is, what block it is up to.  https://ethereum.github.io/beacon-APIs/#/Node/getSyncingStatus

### Example Response
`   {currentSlot:123, targetSlot:12345, peersCount:10, syncing:true}`