### PR TITLE
fix:validator keystores with public key

### DIFF
--- a/internal/ethereum2/validator/validator.go
+++ b/internal/ethereum2/validator/validator.go
@@ -11,37 +11,26 @@ import (
 type ValidatorDto struct {
 	models.Time
 	k8s.MetaDataDto
-	Network                  string        `json:"network"`
-	Client                   string        `json:"client"`
-	Graffiti                 string        `json:"graffiti"`
-	BeaconEndpoints          []string      `json:"beaconEndpoints"`
-	WalletPasswordSecretName string        `json:"walletPasswordSecretName"`
-	Keystores                []KeystoreDto `json:"keystores"`
-	Image                    string        `json:"image"`
+	Network                  string                       `json:"network"`
+	Client                   string                       `json:"client"`
+	Graffiti                 string                       `json:"graffiti"`
+	BeaconEndpoints          []string                     `json:"beaconEndpoints"`
+	WalletPasswordSecretName string                       `json:"walletPasswordSecretName"`
+	Keystores                []ethereum2v1alpha1.Keystore `json:"keystores"`
+	Image                    string                       `json:"image"`
 	sharedAPI.Resources
-}
-
-type KeystoreDto struct {
-	SecretName string `json:"secretName"`
 }
 
 type ValidatorListDto []ValidatorDto
 
 func (dto ValidatorDto) FromEthereum2Validator(validator ethereum2v1alpha1.Validator) ValidatorDto {
-	keystores := []KeystoreDto{}
-	for _, keystore := range validator.Spec.Keystores {
-		keystores = append(keystores, KeystoreDto{
-			SecretName: keystore.SecretName,
-		})
-	}
-
 	dto.Name = validator.Name
 	dto.Time = models.Time{CreatedAt: validator.CreationTimestamp.UTC().Format(shared.JavascriptISOString)}
 	dto.Network = validator.Spec.Network
 	dto.Client = string(validator.Spec.Client)
 	dto.Graffiti = validator.Spec.Graffiti
 	dto.BeaconEndpoints = validator.Spec.BeaconEndpoints
-	dto.Keystores = keystores
+	dto.Keystores = validator.Spec.Keystores
 	dto.CPU = validator.Spec.CPU
 	dto.CPULimit = validator.Spec.CPULimit
 	dto.Memory = validator.Spec.Memory

--- a/internal/ethereum2/validator/validator_service.go
+++ b/internal/ethereum2/validator/validator_service.go
@@ -51,18 +51,11 @@ func (service validatorService) Get(namespacedName types.NamespacedName) (valida
 
 // Create creates ethereum 2.0 beacon node from spec
 func (service validatorService) Create(dto ValidatorDto) (validator ethereum2v1alpha1.Validator, restErr restErrors.IRestErr) {
-	keystores := []ethereum2v1alpha1.Keystore{}
-	for _, keystore := range dto.Keystores {
-		keystores = append(keystores, ethereum2v1alpha1.Keystore{
-			SecretName: keystore.SecretName,
-		})
-	}
-
 	validator.ObjectMeta = dto.ObjectMetaFromMetadataDto()
 	validator.Spec = ethereum2v1alpha1.ValidatorSpec{
 		Network:   dto.Network,
 		Client:    ethereum2v1alpha1.Ethereum2Client(dto.Client),
-		Keystores: keystores,
+		Keystores: dto.Keystores,
 		Image:     dto.Image,
 		Resources: sharedAPIs.Resources{
 			StorageClass: dto.StorageClass,


### PR DESCRIPTION
## Issue Description
it seems we don't pass the keystore public key which is required if client is lighthouse


## Proposed Changes
instead of using this for key store  
```
type KeystoreDto struct {
	SecretName string `json:"secretName"`
}
```
in our validator dto to represent the type `ethereum2v1alpha1.Keystore`

we're gonna use this type ethereum2v1alpha1.Keystore in our dto directly 
which represented as 
```
type Keystore struct {
	// PublicKey is the validator public key in hexadecimal
	PublicKey string `json:"publicKey,omitempty"`
	// SecretName is the kubernetes secret holding [keystore] and [password]
	SecretName string `json:"secretName"`
}
```