### PR TITLE
feat:users can set optional field to empty values for near protocol

### DIFF
--- a/internal/near/near.go
+++ b/internal/near/near.go
@@ -14,14 +14,14 @@ type NearDto struct {
 	k8s.MetaDataDto
 	Network                  string    `json:"network"`
 	Archive                  bool      `json:"archive"`
-	NodePrivateKeySecretName string    `json:"nodePrivateKeySecretName"`
-	ValidatorSecretName      string    `json:"validatorSecretName"`
+	NodePrivateKeySecretName *string   `json:"nodePrivateKeySecretName"`
+	ValidatorSecretName      *string   `json:"validatorSecretName"`
 	MinPeers                 uint      `json:"minPeers"`
 	P2PPort                  uint      `json:"p2pPort"`
 	RPC                      *bool     `json:"rpc"`
 	RPCPort                  uint      `json:"rpcPort"`
 	PrometheusPort           uint      `json:"prometheusPort"`
-	TelemetryURL             string    `json:"telemetryURL"`
+	TelemetryURL             *string   `json:"telemetryURL"`
 	Bootnodes                *[]string `json:"bootnodes"`
 	Image                    string    `json:"image"`
 	sharedAPI.Resources
@@ -35,14 +35,14 @@ func (dto NearDto) FromNEARNode(node nearv1alpha1.Node) NearDto {
 	dto.Time = models.Time{CreatedAt: node.CreationTimestamp.UTC().Format(shared.JavascriptISOString)}
 	dto.Network = string(node.Spec.Network)
 	dto.Archive = node.Spec.Archive
-	dto.NodePrivateKeySecretName = node.Spec.NodePrivateKeySecretName
-	dto.ValidatorSecretName = node.Spec.ValidatorSecretName
+	dto.NodePrivateKeySecretName = &node.Spec.NodePrivateKeySecretName
+	dto.ValidatorSecretName = &node.Spec.ValidatorSecretName
 	dto.MinPeers = node.Spec.MinPeers
 	dto.P2PPort = node.Spec.P2PPort
 	dto.RPC = &node.Spec.RPC
 	dto.RPCPort = node.Spec.RPCPort
 	dto.PrometheusPort = node.Spec.PrometheusPort
-	dto.TelemetryURL = node.Spec.TelemetryURL
+	dto.TelemetryURL = &node.Spec.TelemetryURL
 	dto.Bootnodes = &node.Spec.Bootnodes
 	dto.CPU = node.Spec.CPU
 	dto.CPULimit = node.Spec.CPULimit

--- a/internal/near/near_service.go
+++ b/internal/near/near_service.go
@@ -84,12 +84,12 @@ func (service nearService) Create(dto NearDto) (node nearv1alpha1.Node, restErr 
 // Update updates near node by name from spec
 func (service nearService) Update(dto NearDto, node *nearv1alpha1.Node) (restErr restErrors.IRestErr) {
 
-	if dto.NodePrivateKeySecretName != "" {
-		node.Spec.NodePrivateKeySecretName = dto.NodePrivateKeySecretName
+	if dto.NodePrivateKeySecretName != nil {
+		node.Spec.NodePrivateKeySecretName = *dto.NodePrivateKeySecretName
 	}
 
-	if dto.ValidatorSecretName != "" {
-		node.Spec.ValidatorSecretName = dto.ValidatorSecretName
+	if dto.ValidatorSecretName != nil {
+		node.Spec.ValidatorSecretName = *dto.ValidatorSecretName
 	}
 
 	if dto.MinPeers != 0 {
@@ -113,8 +113,8 @@ func (service nearService) Update(dto NearDto, node *nearv1alpha1.Node) (restErr
 		node.Spec.PrometheusPort = dto.PrometheusPort
 	}
 
-	if dto.TelemetryURL != "" {
-		node.Spec.TelemetryURL = dto.TelemetryURL
+	if dto.TelemetryURL != nil {
+		node.Spec.TelemetryURL = *dto.TelemetryURL
 	}
 
 	if bootnodes := dto.Bootnodes; bootnodes != nil {


### PR DESCRIPTION
### Desorption
users can't set their optional fields like NodePrivateKeySecretName or ValidatorSecretName to empty values after updating them.

### Proposed changes
- use pointer to string instead of string for the near request dto
- check for nil instead for "" in near_service